### PR TITLE
Fix cleanup message typo

### DIFF
--- a/src/chatbot_conversation/models/bots/dummy_bot.py
+++ b/src/chatbot_conversation/models/bots/dummy_bot.py
@@ -190,7 +190,7 @@ class DummyChatbot(ChatbotBase):
             except Exception as e:
                 raise APIException(
                     message=f"Error during API cleanup: {str(e)}",
-                    user_message="Error during API cleansup, see log for more details",
+                    user_message="Error during API cleanup, see log for more details",
                     severity=ErrorSeverity.ERROR,
                     original_error=e,
                 ) from e


### PR DESCRIPTION
## Summary
- fix typo in dummy bot cleanup message

## Testing
- `pytest -q` *(fails: openai.OpenAIError; google.auth.exceptions.DefaultCredentialsError; others)*

------
https://chatgpt.com/codex/tasks/task_e_684a86fdebec83318d0cbfe7f5a8445b