### PR TITLE
Fix moderator round validation message

### DIFF
--- a/src/chatbot_conversation/conversation/loader.py
+++ b/src/chatbot_conversation/conversation/loader.py
@@ -317,7 +317,7 @@ class ConversationConfig(BaseConfigModel):
         invalid_rounds: List[int] = [num for num in round_nums if num > total_rounds]
         if invalid_rounds:
             error_msg = (
-                "Round numbers exceed total rounds ({total_rounds}): "
+                f"Round numbers exceed total rounds ({total_rounds}): "
                 f"{', '.join(map(str, invalid_rounds))}"
             )
             # Just before the specific duplicated section:


### PR DESCRIPTION
## Summary
- fix string interpolation in moderator round validation error message

## Testing
- `pytest tests/test_src/test_chatbot_conversation/test_conversation/test_loader.py::test_moderator_messages_validation -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8722313c8331b48ac624e171ca12