### PR TITLE
Fix bot type docstrings

### DIFF
--- a/src/chatbot_conversation/models/base.py
+++ b/src/chatbot_conversation/models/base.py
@@ -329,9 +329,9 @@ class ChatbotBase(ABC):
     @classmethod
     def _should_retry_on_exception(cls, exception: BaseException) -> bool:
         """
-        Determine if an API call should be retried based on Claude-specific exceptions.
+        Determine if an API call should be retried based on model-specific exceptions.
 
-        Handles common Claude API errors that warrant retry attempts:
+        Handles common API errors that warrant retry attempts:
         - APIError: General API communication failures
         - APIConnectionError: Network connectivity issues
         - RateLimitError: API quota/throughput limits

--- a/src/chatbot_conversation/models/bots/gemini_bot.py
+++ b/src/chatbot_conversation/models/bots/gemini_bot.py
@@ -128,10 +128,10 @@ class GeminiChatbot(ChatbotBase):
     @classmethod
     def _get_class_model_type(cls) -> str:
         """
-        Get the model type identifier for GPT models.
+        Get the model type identifier for Gemini models.
 
         Returns:
-            str: "GPT" as the model type identifier
+            str: "GEMINI" as the model type identifier
         """
         return GEMINI_MODEL_TYPE
 
@@ -153,7 +153,7 @@ class GeminiChatbot(ChatbotBase):
     @classmethod
     def _retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
         """
-        Returns tuple of Claude-specific retryable exception types.
+        Returns tuple of Gemini-specific retryable exception types.
 
         Returns:
             tuple: Exception types that warrant retry attempts

--- a/src/chatbot_conversation/models/bots/gpt_bot.py
+++ b/src/chatbot_conversation/models/bots/gpt_bot.py
@@ -135,7 +135,7 @@ class GPTChatbot(ChatbotBase):
     @classmethod
     def _retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
         """
-        Returns tuple of Claude-specific retryable exception types.
+        Returns tuple of OpenAI-specific retryable exception types.
 
         Returns:
             tuple: Exception types that warrant retry attempts

--- a/src/chatbot_conversation/models/bots/ollama_bot.py
+++ b/src/chatbot_conversation/models/bots/ollama_bot.py
@@ -128,7 +128,7 @@ class OllamaChatbot(ChatbotBase):
     @classmethod
     def _retryable_exceptions(cls) -> tuple[Type[Exception], ...]:
         """
-        Returns tuple of Claude-specific retryable exception types.
+        Returns tuple of Ollama-specific retryable exception types.
 
         Returns:
             tuple: Exception types that warrant retry attempts


### PR DESCRIPTION
## Summary
- fix Gemini model type docstring and clarify return text
- clean up copy‑paste mistakes referencing Claude in other bot docstrings
- generalize retry docstring in base class

## Testing
- `pytest -q` *(fails: google auth / OpenAI credentials, APIException etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a876317cc8331a73d87a7ac6486bc