### PR TITLE
Fix outdated docstring in transcript module

### DIFF
--- a/src/chatbot_conversation/conversation/transcript.py
+++ b/src/chatbot_conversation/conversation/transcript.py
@@ -36,12 +36,11 @@ def save_transcript(
     """Save conversation transcript to a file.
 
     Args:
-        transcript_dir: Path to the transcript directory
-        conversation: List of conversation messages
-        author: Author of the conversation
-        num_rounds: Total number of conversation rounds
-        num_bots: Number of participating bots
-        config_path: Path to the configuration file
+        conversation (List[ConversationMessage]): Conversation history including
+            moderator messages.
+        config (ConversationConfig): Configuration used to generate the
+            conversation.
+        config_path (Path): Path to the configuration file
 
     Returns:
         Path to the saved transcript file


### PR DESCRIPTION
## Summary
- clean up save_transcript docstring so its arguments match the function signature

## Testing
- `pytest -q` *(fails: OpenAIError, DefaultCredentialsError, ConnectError)*

------
https://chatgpt.com/codex/tasks/task_e_684a9ac113908331acae6107a3eb7f8f